### PR TITLE
PPLJLS-8839 First take on the memory leak in IdentifierCacheHandler

### DIFF
--- a/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/identifier/IdentifierCacheHandler.java
+++ b/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/identifier/IdentifierCacheHandler.java
@@ -18,6 +18,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 
 /**
  * Implements two maps for caching identifier and version information. Internally uses
@@ -209,6 +211,21 @@ public class IdentifierCacheHandler {
 			// weakreference already gone compare on keys itself
 			if (obj0 == null || obj1 == null) {
 				return this == key0;
+			}
+
+			if (obj0 instanceof EObject && obj1 instanceof EObject) {
+				EObject eObject0 = (EObject) obj0;
+				EObject eObject1 = (EObject) obj1;
+
+				if (eObject0.eClass().equals(eObject1.eClass())) {
+					EStructuralFeature idFeature = eObject0.eClass().getEStructuralFeature("id");
+
+					if (idFeature != null) {
+						Object id0 = eObject0.eGet(idFeature);
+						Object id1 = eObject1.eGet(idFeature);
+						return id0.equals(id1);
+					}
+				}
 			}
 
 			// still present compare on values

--- a/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/identifier/IdentifierCacheHandler.java
+++ b/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/identifier/IdentifierCacheHandler.java
@@ -213,6 +213,10 @@ public class IdentifierCacheHandler {
 				return this == key0;
 			}
 
+			// since we have no equals and hashcode methods overridden in EObjects,
+			// there is no other way of telling if Keys are equal than by comparing
+			// the value of both EObject's id attribute.
+			// This change was needed due to memory leaks in asm-execution, see PPLJLS-8839.
 			if (obj0 instanceof EObject && obj1 instanceof EObject) {
 				EObject eObject0 = (EObject) obj0;
 				EObject eObject1 = (EObject) obj1;


### PR DESCRIPTION
The memory leak has been noticed in the asm-execution server. When the IdentifierCacheHandler.Key (that is a key of the IdentifierCacheHandler#idMap map) is an EObject, the idMap grows enormously because of the fact that we have no equals/hashCode methods overridden in our EMF objects. The result is that we have duplicated elements stored in this map which are not needed there - and probably are not being cleared by the garbage collector.

The solution here was to check if the key is an EObject and has the id attribute - and if that's the case, then compare the ids. If they are the same, that means we try to put the new version of the same object to the idMap (which makes sense since we do not need the older versions in the idMap map) - so thanks to the new implementation we put the new version of the object in the place of the older one.